### PR TITLE
Change usages of ToLower into ToLowerInvariant

### DIFF
--- a/Assets/Plugins/Web3AuthSDK/Web3Auth.cs
+++ b/Assets/Plugins/Web3AuthSDK/Web3Auth.cs
@@ -62,14 +62,14 @@ public class Web3Auth : MonoBehaviour
         this.initParams = new Dictionary<string, object>();
 
         this.initParams["clientId"] = clientId;
-        this.initParams["network"] = network.ToString().ToLower();
+        this.initParams["network"] = network.ToString().ToLowerInvariant();
 
         if (!string.IsNullOrEmpty(redirectUri))
             this.initParams["redirectUrl"] = redirectUri;
 
         Application.deepLinkActivated += onDeepLinkActivated;
         if (!string.IsNullOrEmpty(Application.absoluteURL))
-            onDeepLinkActivated(Application.absoluteURL);
+            onDeepLinkActivated(Application.absoluteURL);C
 
 #if UNITY_EDITOR
         Web3AuthSDK.Editor.Web3AuthDebug.onURLRecieved += (Uri url) =>
@@ -112,9 +112,9 @@ public class Web3Auth : MonoBehaviour
             this.initParams["clientId"] = this.web3AuthOptions.clientId;
 
         if (this.web3AuthOptions.buildEnv != null)
-            this.initParams["buildEnv"] = this.web3AuthOptions.buildEnv.ToString().ToLower();
+            this.initParams["buildEnv"] = this.web3AuthOptions.buildEnv.ToString().ToLowerInvariant();
 
-        this.initParams["network"] = this.web3AuthOptions.network.ToString().ToLower();
+        this.initParams["network"] = this.web3AuthOptions.network.ToString().ToLowerInvariant();
 
         if (this.web3AuthOptions.useCoreKitKey.HasValue)
             this.initParams["useCoreKitKey"] = this.web3AuthOptions.useCoreKitKey.Value;


### PR DESCRIPTION
This fixes a very hard-to-spot bug where Web3Auth & OpenLogin started to give various configuration errors on some specific devices. Here is where we reported it: https://web3auth.io/community/t/invalid-constructor-params-invalid-environment-settings/6643

It turns out all those devices were Turkish, and the character "ı" (or "dotless i" as non-Turkish people would say) was the reason. 

You see, in Turkish, lowercasing/uppercasing rules are different, because we have a distinction between "I" and "İ" where "I".ToLower() == "ı" and "İ".ToLower() == "i" which makes sense in Turkish, and "I".ToLower() == "i" makes sense for any other language, but obviously these two rules don't mix well. And ToLower() uses the current culture information of the device. Which can make network.ToString().ToLower() into "maınnet" and buildEnv.ToString() into "productıon" "stagıng" or "testıng".

To sum up: ToLower uses current device's region settings for lowercasing a string, which can be different for some Turkic languages. ToLowerInvariant is what should be used where this behavior doesn't make sense.