### PR TITLE
fix: resolve clientId before fetchProjectConfig to avoid empty project_id

### DIFF
--- a/Assets/Plugins/Web3AuthSDK/Web3Auth.cs
+++ b/Assets/Plugins/Web3AuthSDK/Web3Auth.cs
@@ -100,9 +100,26 @@ public class Web3Auth : MonoBehaviour
 #endif
     }
 
+    private string getResolvedClientId()
+    {
+        if (!string.IsNullOrEmpty(this.web3AuthOptions?.clientId))
+            return this.web3AuthOptions.clientId;
+
+        return this.clientId;
+    }
+
     public async void setOptions(Web3AuthOptions web3AuthOptions)
     {
         this.web3AuthOptions = web3AuthOptions;
+
+        var resolvedClientId = getResolvedClientId();
+        if (string.IsNullOrEmpty(resolvedClientId))
+        {
+            throw new Exception("clientId is required. Set it in Web3AuthOptions or the Web3Auth Inspector field.");
+        }
+
+        this.web3AuthOptions.clientId = resolvedClientId;
+        this.initParams["clientId"] = resolvedClientId;
 
         bool isfetchConfigSuccess = await fetchProjectConfig();
 
@@ -127,9 +144,6 @@ public class Web3Auth : MonoBehaviour
 
             if (this.web3AuthOptions.loginConfig != null)
                 this.initParams["loginConfig"] = JsonConvert.SerializeObject(this.web3AuthOptions.loginConfig, settings);
-
-            if (this.web3AuthOptions.clientId != null)
-                this.initParams["clientId"] = this.web3AuthOptions.clientId;
 
             if (this.web3AuthOptions.buildEnv != null)
                 this.initParams["buildEnv"] = this.web3AuthOptions.buildEnv.ToString().ToLower();
@@ -921,7 +935,7 @@ public class Web3Auth : MonoBehaviour
     {
         TaskCompletionSource<bool> fetchProjectConfigResponse = new TaskCompletionSource<bool>();
         StartCoroutine(Web3AuthApi.getInstance().fetchProjectConfig(
-            this.web3AuthOptions.clientId,
+            getResolvedClientId(),
             this.web3AuthOptions.network.ToString().ToLower(),
             (response =>
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Motivation and Context
`fetchProjectConfig` was sending `project_id=` (empty) in some integrations because it only read `Web3AuthOptions.clientId`, while the SDK also supports setting `clientId` via the Unity Inspector `[SerializeField]` on the `Web3Auth` component.

When developers configured `clientId` in the Inspector but omitted it from `setOptions()`, the config API was called with an empty project ID.

## Description
- Add `getResolvedClientId()` to prefer `Web3AuthOptions.clientId` and fall back to the Inspector field.
- Validate that a non-empty `clientId` exists before calling `fetchProjectConfig`.
- Sync the resolved value onto `web3AuthOptions.clientId` and `initParams`.
- Use the resolved client ID when calling the configuration API.

## How has this been tested?
- Verified code path: `setOptions()` with Inspector-only `clientId` now resolves before `fetchProjectConfig`.
- Verified code path: missing `clientId` in both sources throws a clear exception instead of calling the API with an empty `project_id`.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code requires a db migration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small initialization bug fix in client ID resolution; no changes to crypto, session, or login flows beyond using the correct project ID.
> 
> **Overview**
> Fixes **empty `project_id`** on the configuration API when developers set **`clientId` only on the Unity Inspector** `Web3Auth` component and omit it in `setOptions()`.
> 
> Adds **`getResolvedClientId()`** to prefer `Web3AuthOptions.clientId` and fall back to the serialized Inspector field. **`setOptions()`** now requires a resolved ID (clear exception if missing), writes it to **`web3AuthOptions.clientId`** and **`initParams`**, and **`fetchProjectConfig`** uses the same resolver instead of options-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c132219c7f245591ad3abf60d96e0d1c37d6177f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->